### PR TITLE
FIxes for command-line processing

### DIFF
--- a/bin/xumlidot
+++ b/bin/xumlidot
@@ -5,6 +5,6 @@ require_relative '../lib/xumlidot'
 options = ::Xumlidot::Options.parse(ARGV)
 
 # TODO: user input
-directories = [ARGV[0]]
+directories = ARGV
 
 ::Xumlidot::Loader.new(directories, options).load

--- a/lib/xumlidot/options.rb
+++ b/lib/xumlidot/options.rb
@@ -79,7 +79,7 @@ module Xumlidot
           @options.rails = v
         end
 
-        opts.on('-e', '--exclude [TEXT[', 'Output usage links on the diagram') do |v|
+        opts.on('-e', '--exclude [TEXT]', 'Exclude directories or files by pattern') do |v|
           @options.exclude = v
         end
 


### PR DESCRIPTION
`xumlidot` wasn't processing more than one directory, and the help output for the `--exclude` option was wrong.
This PR fixes both problems.