### PR TITLE
Remove pry from production code

### DIFF
--- a/lib/xumlidot/parsers.rb
+++ b/lib/xumlidot/parsers.rb
@@ -3,7 +3,6 @@
 require 'ruby_parser'
 require 'sexp_processor'
 require 'ostruct'
-require 'pry'
 
 require_relative 'parsers/generic'
 require_relative 'parsers/args'


### PR DESCRIPTION
Since `pry` is marked as a _development_ dependency, it will **not**
be installed when running

```
gem install xumlidot
```

Xumlidot will then complain about not being able to load `pry`.

As `pry` is not used in production code, we remove the `require` statement.