### PR TITLE
Fix CI build

### DIFF
--- a/lib/xumlidot/options.rb
+++ b/lib/xumlidot/options.rb
@@ -10,11 +10,28 @@ module Xumlidot
   class Options
     @options = nil
 
+    attr_accessor(*%i[
+                    composition
+                    debug
+                    diagram_type
+                    exclude
+                    inheritance
+                    model_name
+                    rails
+                    respond_to
+                    send
+                    sequence
+                    split
+                    title
+                    usage
+                    use_debug_ids
+                  ])
+
     class << self
       attr_accessor :options
 
       def method_missing(method_name, *_args, &_block)
-        return options.send(method_name) if options.respond_to?(method_name)
+        return options.public_send(method_name) if options.respond_to?(method_name)
 
         raise OptionsError.new, "Unknown Option #{method_name}"
       end
@@ -24,10 +41,8 @@ module Xumlidot
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
-    def self.parse(args)
-      @options = OpenStruct.new
+    def self.parse(args) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      @options = new
 
       @options.title = 'Class Diagram'
       @options.model_name = 'My Model'
@@ -120,7 +135,5 @@ module Xumlidot
 
       @options
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/spec/integration/lib_composition/class_composition_spec.rb
+++ b/spec/integration/lib_composition/class_composition_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe 'Output of lib/composition/class' do
   let(:directory) { 'spec/app/lib/composition/class' }
 
-  let(:expect_dot) { File.open('spec/integration/lib_composition/class_composition.dot').read }
-  let(:expect_xmi) { File.open('spec/integration/lib_composition/class_composition.xmi').read }
+  let(:expect_dot) { File.read('spec/integration/lib_composition/class_composition.dot') }
+  let(:expect_xmi) { File.read('spec/integration/lib_composition/class_composition.xmi') }
 
   specify { expect { generate_dot(directory) }.to output(expect_dot).to_stdout }
   specify { expect { generate_xmi(directory) }.to output(expect_xmi).to_stdout }

--- a/spec/integration/lib_composition/module_composition_spec.rb
+++ b/spec/integration/lib_composition/module_composition_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe 'Output of lib/composition/module' do
   let(:directory) { 'spec/app/lib/composition/module' }
 
-  let(:expect_dot) { File.open('spec/integration/lib_composition/module_composition.dot').read }
-  let(:expect_xmi) { File.open('spec/integration/lib_composition/module_composition.xmi').read }
+  let(:expect_dot) { File.read('spec/integration/lib_composition/module_composition.dot') }
+  let(:expect_xmi) { File.read('spec/integration/lib_composition/module_composition.xmi') }
 
   specify { expect { generate_dot(directory) }.to output(expect_dot).to_stdout }
   specify { expect { generate_xmi(directory) }.to output(expect_xmi).to_stdout }

--- a/spec/integration/lib_methods/method_name_escaping_spec.rb
+++ b/spec/integration/lib_methods/method_name_escaping_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 describe 'Output of lib/methods' do
-  let(:directory) { 'spec/app/lib/methods/' }
+  let(:directory) { 'spec/app/lib/methods/method_name_escaping.rb' }
 
   let(:expect_dot) { Pathname.new(__dir__).join('method_name_escaping.dot').read }
   let(:expect_xmi) { Pathname.new(__dir__).join('method_name_escaping.xmi').read }

--- a/spec/integration/lib_version/lib_version_spec.rb
+++ b/spec/integration/lib_version/lib_version_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'Output of lib/version.rb' do
   let(:directory) { 'spec/app/lib/version' }
   # let(:expect_xmi) { File.open('spec/integration/lib_version/lib_version.xmi lib_version.xmi').read }
-  let(:expect_dot) { File.open('spec/integration/lib_version/lib_version.dot').read }
+  let(:expect_dot) { File.read('spec/integration/lib_version/lib_version.dot') }
 
   specify { expect { generate_dot(directory) }.to output(expect_dot).to_stdout }
 

--- a/xumlidot.gemspec
+++ b/xumlidot.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.summary = %(Generates DOT and XMI for Ruby and Rails UML Class Diagrams. )
   s.rubygems_version = '1.3.6'
 
+  s.metadata['rubygems_mfa_required'] = 'true'
+
   s.require_paths = %w[lib]
   s.files = Dir['lib/*.rb'] + Dir['bin/*']
   s.files += Dir['lib/**/*']


### PR DESCRIPTION
We fix some conflicts cause after merging several PRs at once
and make RuboCop happy by removing the use of `OpenStruct`.